### PR TITLE
v 1.10

### DIFF
--- a/SolrCore/Extensions.cs
+++ b/SolrCore/Extensions.cs
@@ -11,10 +11,11 @@ namespace SolrCore
 
     public static class Extensions
     {
-        public static void AddSolrCore<TKey, T>(this IServiceCollection serviceCollection, string coreName) where T : class, IEntity<TKey>, ISolrId where TKey : IEquatable<TKey>
+        public static void AddSolrCore<TKey, T>(this IServiceCollection serviceCollection, string coreName, bool useOverwriteProtection = true) where T : class, IEntity<TKey>, ISolrId where TKey : IEquatable<TKey>
         {
             serviceCollection.AddSingleton<ISolrRepository<TKey, T>, SolrRepository<TKey, T>>();
             SolrRepository<TKey, T>.SetCoreName(coreName);
+            SolrRepository<TKey, T>.SetOverwriteProtection(useOverwriteProtection);
         }
 
         public static void AddSolr(this IServiceCollection serviceCollection, Type serializer = null, Type setter = null)

--- a/SolrCore/Extensions.cs
+++ b/SolrCore/Extensions.cs
@@ -11,7 +11,7 @@ namespace SolrCore
 
     public static class Extensions
     {
-        public static void AddSolrCore<TKey, T>(this IServiceCollection serviceCollection, string coreName, bool useOverwriteProtection = true) where T : class, IEntity<TKey>, ISolrId where TKey : IEquatable<TKey>
+        public static void AddSolrCore<TKey, T>(this IServiceCollection serviceCollection, string coreName, bool useOverwriteProtection = true) where T : class where TKey : IEquatable<TKey>
         {
             serviceCollection.AddSingleton<ISolrRepository<TKey, T>, SolrRepository<TKey, T>>();
             SolrRepository<TKey, T>.SetCoreName(coreName);

--- a/SolrCore/Models/ISolrId.cs
+++ b/SolrCore/Models/ISolrId.cs
@@ -1,6 +1,9 @@
 namespace SolrCore.Models
 {
-    public interface ISolrId
+    using System;
+    using EntityModels;
+
+    public interface ISolrId<TKey>:IEntity<TKey> where TKey:IEquatable<TKey>
     {
         void NewId();
     }

--- a/SolrCore/Models/IdResponse.cs
+++ b/SolrCore/Models/IdResponse.cs
@@ -1,0 +1,10 @@
+namespace SolrCore.Models
+{
+    using System;
+
+    public class IdResponse<TKey> where TKey: IEquatable<TKey>
+    {
+        [SolrFieldName("id")]
+        public TKey Id { get; set; }
+    }
+}

--- a/SolrCore/Models/SolrEntity.cs
+++ b/SolrCore/Models/SolrEntity.cs
@@ -1,5 +1,6 @@
 ﻿namespace SolrCore.Models
 {
+    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
@@ -14,9 +15,9 @@
 
         static SolrEntity()
         {
-            Translations = typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            Translations = new ConcurrentDictionary<string, string>(typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance)
                 .Where(p => p.GetCustomAttribute(typeof(SolrFieldNameAttribute)) != null)
-                .ToDictionary(x => x.Name, x => ((SolrFieldNameAttribute)x.GetCustomAttribute(typeof(SolrFieldNameAttribute))).Name);
+                .ToDictionary(x => x.Name, x => ((SolrFieldNameAttribute)x.GetCustomAttribute(typeof(SolrFieldNameAttribute))).Name));
         }
 
         protected static void SetStandardDefaults()

--- a/SolrCore/README.md
+++ b/SolrCore/README.md
@@ -21,6 +21,15 @@ see:https://www.nuget.org/packages/EbaSoft.SolrCore
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/27173723-bc9258dd-27eb-4c39-9b2b-c33cae354883?action=collection%2Ffork&collection-url=entityId%3D27173723-bc9258dd-27eb-4c39-9b2b-c33cae354883%26entityType%3Dcollection%26workspaceId%3Ddceebdce-605e-4c97-82d4-4415b2d0d34b#?env%5BDevelopment%5D=W3sia2V5IjoidXJsIiwidmFsdWUiOiJodHRwOi8vbG9jYWxob3N0OjUwMDAiLCJlbmFibGVkIjp0cnVlLCJ0eXBlIjoiZGVmYXVsdCIsInNlc3Npb25WYWx1ZSI6Imh0dHA6Ly9sb2NhbGhvc3Q6NTAwMCIsInNlc3Npb25JbmRleCI6MH0seyJrZXkiOiJ0b2tlbiIsInZhbHVlIjoiYXNvYXNqZGZpODkwNzIzNHEwOTh1aXdxZWZyIiwiZW5hYmxlZCI6dHJ1ZSwidHlwZSI6InNlY3JldCIsInNlc3Npb25WYWx1ZSI6ImFzb2FzamRmaTg5MDcyMzRxMDk4dWl3cWVmciIsInNlc3Npb25JbmRleCI6MX1d)
 
 Changes:
+
+v1.0.10 -
+
+Added optional checking for duplicate ids.
+
+Changed Translations dictionary to concurrent.
+
+Added test controllers for IOnAdd<> types.
+
 v1.0.9 -
 
 Added Parent Which and Child Of Solr queries.

--- a/SolrCore/README.md
+++ b/SolrCore/README.md
@@ -30,6 +30,10 @@ Changed Translations dictionary to concurrent.
 
 Added test controllers for IOnAdd<> types.
 
+Made repository more generic for expanded use.
+
+Fixed delete to work with items that have children. 
+
 v1.0.9 -
 
 Added Parent Which and Child Of Solr queries.

--- a/SolrCore/Repository/ISolrRepository.cs
+++ b/SolrCore/Repository/ISolrRepository.cs
@@ -8,15 +8,18 @@ namespace SolrCore.Repository
     using Query;
     using QueryBuilder;
 
-    public interface ISolrRepository<TKey, T> where T : IEntity<TKey> where TKey : IEquatable<TKey>
+    public interface ISolrRepository<TKey, T> where T : class where TKey : IEquatable<TKey>
     {
         Task<bool> AddAsync(T item, bool commit = true);
         Task<bool> AddRangeAsync(IEnumerable<T> items, bool commit = true);
         Task<SolrResponse<T>> GetAsync(IQuery query, bool ignoreDefaultQueries = false);
-        Task<bool> UpdateAsync<TUpdate>(TUpdate item, bool commit = true) where TUpdate : SolrEntity<TUpdate>, IEntity<TKey>;
-        Task<bool> UpdateRangeAsync<TUpdate>(IEnumerable<TUpdate> items, bool commit = true) where TUpdate : SolrEntity<TUpdate>, IEntity<TKey>;
+        Task<bool> UpdateAsync<TUpdate>(TUpdate item, bool commit = true) where TUpdate : class;
+        Task<bool> UpdateRangeAsync<TUpdate>(IEnumerable<TUpdate> items, bool commit = true) where TUpdate : class;
         Task<bool> DeleteAsync<TDelete>(TKey id, bool commit = true) where TDelete : class, IEntity<TKey>, new();
         Task<bool> DeleteAsync<TDelete>(Query query, bool commit = true) where TDelete : SolrEntity<TDelete>, IEntity<TKey>;
         Task<bool> DeleteAllAsync<TDelete>(bool commit = true) where TDelete : SolrEntity<TDelete>, IEntity<TKey>;
+        Task<bool> UpdateAsync(T item, bool commit = true);
+        Task<bool> UpdateRangeAsync(IEnumerable<T> items, bool commit = true);
+        Task<SolrResponse<TResult>> GetAsync<TResult>(IQuery query, bool ignoreDefaultQueries = false) where TResult : class;
     }
 }

--- a/SolrCore/SolrCore.csproj
+++ b/SolrCore/SolrCore.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <PackageId>Ebasoft.SolrCore</PackageId>
-        <Version>1.0.9</Version>
+        <Version>1.0.10</Version>
         <Authors>Ebasoft</Authors>
         <Company>Ebasoft</Company>
         <Product>SolrCore</Product>
@@ -12,11 +12,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="EbaSoft.EntityDefaults" Version="1.0.1"/>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0"/>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.1"/>
-        <PackageReference Include="System.Text.Json" Version="7.0.2"/>
-        <None Include="README.md" Pack="true" PackagePath="\"/>
+        <PackageReference Include="EbaSoft.EntityDefaults" Version="1.0.1" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+        <PackageReference Include="System.Text.Json" Version="7.0.2" />
+        <None Include="README.md" Pack="true" PackagePath="\" />
     </ItemGroup>
 </Project>

--- a/SolrCoreWeb/Controllers/OtherTestAuthenticatedController.cs
+++ b/SolrCoreWeb/Controllers/OtherTestAuthenticatedController.cs
@@ -1,0 +1,75 @@
+namespace SolrCoreWeb.Controllers
+{
+    using Microsoft.AspNetCore.Authentication.JwtBearer;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Mvc;
+    using Models;
+    using SolrCore.Models;
+    using SolrCore.Query;
+    using SolrCore.QueryBuilder;
+    using SolrCore.Repository;
+
+    [ApiController]
+    [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
+    [Route("[controller]")]
+    public class OtherTestAuthenticatedController : ControllerBase
+    {
+        private readonly ILogger<OtherTestAuthenticatedController> _logger;
+        private readonly ISolrRepository<string, OtherItem> _solrRepository;
+
+        public OtherTestAuthenticatedController(ILogger<OtherTestAuthenticatedController> logger,
+            ISolrRepository<string, OtherItem> solrRepository)
+        {
+            _logger = logger;
+            _solrRepository = solrRepository;
+        }
+
+        [HttpPost]
+        public async Task<bool> Post(OtherItem item)
+        {
+            var res = await _solrRepository.AddAsync(item);
+            return res;
+        }
+
+        [HttpPost("Range")]
+        public async Task<bool> PostRange(IEnumerable<OtherItem> items)
+        {
+            var res = await _solrRepository.AddRangeAsync(items);
+            return res;
+        }
+
+        [HttpPut]
+        public async Task<bool> Put(OtherItem item)
+        {
+            var update = Map(item);
+            var res = await _solrRepository.UpdateAsync(update);
+            return res;
+        }
+
+        [HttpPut("Range")]
+        public async Task<bool> PutRange(IEnumerable<OtherItem> items)
+        {
+            var updates = items.Select(Map);
+            var res = await _solrRepository.UpdateRangeAsync(updates);
+            return res;
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<bool> Delete(string id)
+        {
+            var res = await _solrRepository.DeleteAsync<ItemUpdate>(id);
+            return res;
+        }
+
+        private static ItemUpdate Map(OtherItem item)
+        {
+            return new ItemUpdate
+            {
+                Id = item.Id,
+                Name = string.IsNullOrEmpty(item.Name) ? null : new Set(item.Name),
+                Type = item.Type.HasValue ? new Set(item.Type) : null,
+                Price = item.Price.HasValue ? new Set(item.Price) : null
+            };
+        }
+    }
+}

--- a/SolrCoreWeb/Controllers/OtherTestController.cs
+++ b/SolrCoreWeb/Controllers/OtherTestController.cs
@@ -1,0 +1,73 @@
+namespace SolrCoreWeb.Controllers
+{
+    using Microsoft.AspNetCore.Mvc;
+    using Models;
+    using SolrCore;
+    using SolrCore.Models;
+    using SolrCore.Query;
+    using SolrCore.QueryBuilder;
+    using SolrCore.Repository;
+
+    [ApiController]
+    [Route("[controller]")]
+    public class OtherTestController : ControllerBase
+    {
+        private readonly ILogger<OtherTestController> _logger;
+        private readonly ISolrRepository<string, OtherItem> _solrRepository;
+
+        public OtherTestController(ILogger<OtherTestController> logger,
+            ISolrRepository<string, OtherItem> solrRepository)
+        {
+            _logger = logger;
+            _solrRepository = solrRepository;
+        }
+
+        [HttpPost]
+        public async Task<bool> Post(OtherItem item)
+        {
+            var res = await _solrRepository.AddAsync(item);
+            return res;
+        }
+
+        [HttpPost("Range")]
+        public async Task<bool> PostRange(IEnumerable<OtherItem> items)
+        {
+            var res = await _solrRepository.AddRangeAsync(items);
+            return res;
+        }
+
+        [HttpPut]
+        public async Task<bool> Put(OtherItem item)
+        {
+            var update = Map(item);
+            var res = await _solrRepository.UpdateAsync(update);
+            return res;
+        }
+
+        [HttpPut("Range")]
+        public async Task<bool> PutRange(IEnumerable<OtherItem> items)
+        {
+            var updates = items.Select(Map);
+            var res = await _solrRepository.UpdateRangeAsync(updates);
+            return res;
+        }
+
+        private static ItemUpdate Map(OtherItem item)
+        {
+            return new ItemUpdate
+            {
+                Id = item.Id,
+                Name = string.IsNullOrEmpty(item.Name) ? null : new Set(item.Name),
+                Type = item.Type.HasValue ? new Set(item.Type) : null,
+                Price = item.Price.HasValue ? new Set(item.Price) : null
+            };
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<bool> Delete(string id)
+        {
+            var res = await _solrRepository.DeleteAsync<ItemUpdate>(id);
+            return res;
+        }
+    }
+}

--- a/SolrCoreWeb/Models/Item.cs
+++ b/SolrCoreWeb/Models/Item.cs
@@ -5,7 +5,7 @@ namespace SolrCoreWeb.Models
     using SolrCore.Models;
 
     [JsonObject(ItemNullValueHandling = NullValueHandling.Ignore)]
-    public class Item : SolrEntity<Item>, IEntity<string>, IName, ICreated<string>, ILastUpdated<string>, ISolrId, ISoftDelete
+    public class Item : SolrEntity<Item>, IName, ICreated<string>, ILastUpdated<string>, ISolrId<string>, ISoftDelete
     {
         static Item()
         {
@@ -71,7 +71,7 @@ namespace SolrCoreWeb.Models
         }
     }
 
-    public class SolrChild : SolrEntity<SolrChild>, IEntity<string>, ISolrId
+    public class SolrChild : SolrEntity<SolrChild>, ISolrId<string>
     {
         [SolrFieldName("type_i")]
         public int? Type { get; set; }
@@ -91,7 +91,7 @@ namespace SolrCoreWeb.Models
         }
     }
 
-    public class SolrChild2 : SolrEntity<SolrChild2>, IEntity<string>, ISolrId
+    public class SolrChild2 : SolrEntity<SolrChild2>, ISolrId<string>
     {
         [SolrFieldName("type_i")]
         public int? Type { get; set; }
@@ -115,7 +115,7 @@ namespace SolrCoreWeb.Models
         }
     }
 
-    public class SolrChild3 : SolrEntity<SolrChild3>, IEntity<string>, ISolrId
+    public class SolrChild3 : SolrEntity<SolrChild3>, ISolrId<string>
     {
         [SolrFieldName("child")]
         public SolrChild? Child { get; set; }

--- a/SolrCoreWeb/Models/OtherItem.cs
+++ b/SolrCoreWeb/Models/OtherItem.cs
@@ -1,0 +1,63 @@
+namespace SolrCoreWeb.Models
+{
+    using EntityModels;
+    using SolrCore.Models;
+
+    public class OtherItem : SolrEntity<OtherItem>, IEntity<string>, IOnAdd<string>, ISolrId
+    {
+        static OtherItem()
+        {
+            SetStandardDefaults();
+        }
+
+        [SolrFieldName("description_s")]
+        public string? Description { get; set; }
+
+        [SolrFieldName("type_i")]
+        public int? Type { get; set; }
+
+        [SolrFieldName("price_d")]
+        public double? Price { get; set; }
+
+        [SolrFieldName("createdDate_dt")]
+        public DateTime CreatedDate { get; set; }
+
+        [SolrFieldName("createdUserId_s")]
+        public string? CreatedUserId { get; set; }
+
+        [SolrFieldName("id")]
+        public string? Id { get; set; }
+
+        [SolrFieldName("lastUpdatedDate_dt")]
+        public DateTime LastUpdatedDate { get; set; }
+
+        [SolrFieldName("lastUpdatedUserId_s")]
+        public string? LastUpdatedUserId { get; set; }
+
+        [SolrFieldName("name_s")]
+        public string? Name { get; set; }
+
+        [SolrFieldName("active_b")]
+        public bool Active { get; set; }
+
+        public void NewId()
+        {
+            Id = Guid.NewGuid().ToString();
+        }
+
+        public void OnAdd(string id, params object[] objects)
+        {
+            NewId();
+            Active = true;
+            CreatedDate = DateTime.UtcNow;
+            LastUpdatedDate = DateTime.UtcNow;
+            if (string.IsNullOrEmpty(id))
+            {
+                return;
+            }
+
+            CreatedUserId = id;
+            LastUpdatedUserId = id;
+        }
+    }
+}

--- a/SolrCoreWeb/Models/OtherItem.cs
+++ b/SolrCoreWeb/Models/OtherItem.cs
@@ -3,7 +3,7 @@ namespace SolrCoreWeb.Models
     using EntityModels;
     using SolrCore.Models;
 
-    public class OtherItem : SolrEntity<OtherItem>, IEntity<string>, IOnAdd<string>, ISolrId
+    public class OtherItem : SolrEntity<OtherItem>, IOnAdd<string>, ISolrId<string>
     {
         static OtherItem()
         {

--- a/SolrCoreWeb/Program.cs
+++ b/SolrCoreWeb/Program.cs
@@ -81,6 +81,7 @@ builder.Services.AddHttpClient("SolrCore", httpClient => { httpClient.BaseAddres
 builder.Services.AddSingleton<ITokenManager, TokenManager>();
 builder.Services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
 builder.Services.AddSolrCore<string, Item>("test");
+builder.Services.AddSolrCore<string, OtherItem>("other_test", false);
 builder.Services.AddSolr(setter: typeof(EntitySetter));
 
 var app = builder.Build();

--- a/SolrCoreWeb/SolrCoreWeb.csproj
+++ b/SolrCoreWeb/SolrCoreWeb.csproj
@@ -7,35 +7,35 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="EbaSoft.SolrCore" Version="1.0.4"/>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.5"/>
-        <PackageReference Include="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Version="7.0.5"/>
-        <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.5"/>
-        <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="7.0.5"/>
-        <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.5"/>
-        <PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="7.0.5"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.5"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.5"/>
+        <PackageReference Include="EbaSoft.SolrCore" Version="1.0.4" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.5" />
+        <PackageReference Include="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Version="7.0.5" />
+        <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.5" />
+        <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="7.0.5" />
+        <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.5" />
+        <PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="7.0.5" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.5" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.5" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.5">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.5"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.5" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.5">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.5"/>
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.5" />
 
-        <PackageReference Include="Npgsql" Version="7.0.2"/>
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.3"/>
-        <PackageReference Include="EFCore.NamingConventions" Version="7.0.2"/>
+        <PackageReference Include="Npgsql" Version="7.0.2" />
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.3" />
+        <PackageReference Include="EFCore.NamingConventions" Version="7.0.2" />
 
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\SolrCore\SolrCore.csproj"/>
+        <ProjectReference Include="..\SolrCore\SolrCore.csproj" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Added optional checking for duplicate ids.

Changed Translations dictionary to concurrent.

Added test controllers for IOnAdd<> types.

Made repository more generic for expanded use.

Fixed delete to work with items that have children. 